### PR TITLE
Point links to the project-status-badges repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 Indicates the primary reason a project was created.
 
-#### experimental: [![origin experimental badge](https://img.shields.io/badge/origin-experimental-blue.png)](https://img.shields.io/badge/origin-experimental-blue.png])
+#### experimental: [![origin experimental badge](https://img.shields.io/badge/origin-experimental-blue.png)](https://github.com/insin/project-status-badges)
 
 The project was created primarily as an experiment.
 
-#### learning: [![origin learning badge](https://img.shields.io/badge/origin-learning-blue.png)](https://img.shields.io/badge/origin-learning-blue.png])
+#### learning: [![origin learning badge](https://img.shields.io/badge/origin-learning-blue.png)](https://github.com/insin/project-status-badges)
 
 The project was created primarily for the learning experience of making it.
 
-#### need: [![origin need badge](https://img.shields.io/badge/origin-need-blue.png)](https://img.shields.io/badge/origin-need-blue.png])
+#### need: [![origin need badge](https://img.shields.io/badge/origin-need-blue.png)](https://github.com/insin/project-status-badges)
 
 The project was created primarily because the author needed it.
 
@@ -20,27 +20,27 @@ The project was created primarily because the author needed it.
 
 Indicates how a project's author is using it.
 
-#### abandoned: [![author-usage abandoned badge](https://img.shields.io/badge/author--usage-abandoned-red.png)](https://img.shields.io/badge/author--usage-abandoned-red.png])
+#### abandoned: [![author-usage abandoned badge](https://img.shields.io/badge/author--usage-abandoned-red.png)](https://github.com/insin/project-status-badges#author-usage)
 
 The project is no longer being used by its author, nor do they expect to use it again in new projects.
 
-#### active: [![author-usage active badge](https://img.shields.io/badge/author--usage-active-green.png)](https://img.shields.io/badge/author--usage-active-green.png])
+#### active: [![author-usage active badge](https://img.shields.io/badge/author--usage-active-green.png)](https://github.com/insin/project-status-badges#author-usage)
 
 The project is being actively used by its author.
 
-#### dependency: [![author-usage dependency badge](https://img.shields.io/badge/author--usage-dependency-green.png)](https://img.shields.io/badge/author--usage-dependency-green.png])
+#### dependency: [![author-usage dependency badge](https://img.shields.io/badge/author--usage-dependency-green.png)](https://github.com/insin/project-status-badges#author-usage)
 
 The project is a dependency of the author's other projects.
 
-#### inactive: [![author-usage inactive badge](https://img.shields.io/badge/author--usage-inactive-lightgrey.png)](https://img.shields.io/badge/author--usage-inactive-lightgrey.png])
+#### inactive: [![author-usage inactive badge](https://img.shields.io/badge/author--usage-inactive-lightgrey.png)](https://github.com/insin/project-status-badges#author-usage)
 
 The project is not currently being used by its author.
 
-#### never: [![author-usage never badge](https://img.shields.io/badge/author--usage-never-red.png)](https://img.shields.io/badge/author--usage-never-red.png])
+#### never: [![author-usage never badge](https://img.shields.io/badge/author--usage-never-red.png)](https://github.com/insin/project-status-badges#author-usage)
 
 The project has *never* been used by its author, other than while making it.
 
-#### production: [![author-usage production badge](https://img.shields.io/badge/author--usage-production-green.png)](https://img.shields.io/badge/author--usage-production-green.png])
+#### production: [![author-usage production badge](https://img.shields.io/badge/author--usage-production-green.png)](https://github.com/insin/project-status-badges#author-usage)
 
 The author has code in production which uses the project.
 


### PR DESCRIPTION
instead of linking to the images, so that people know the context of these images.
